### PR TITLE
Use MySqlConnector, not MySql.Data

### DIFF
--- a/src/Serilog.Sinks.MySQL/Serilog.Sinks.MySQL.csproj
+++ b/src/Serilog.Sinks.MySQL/Serilog.Sinks.MySQL.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="8.0.8-dmr" />
+    <PackageReference Include="MySqlConnector" Version="0.40.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />

--- a/src/Serilog.Sinks.MySQL/Serilog.Sinks.MySQL.csproj
+++ b/src/Serilog.Sinks.MySQL/Serilog.Sinks.MySQL.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="0.40.2" />
+    <PackageReference Include="MySqlConnector" Version="0.32.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />

--- a/src/Serilog.Sinks.MySQL/Sinks/MySQL/MySqlSink.cs
+++ b/src/Serilog.Sinks.MySQL/Sinks/MySQL/MySqlSink.cs
@@ -38,8 +38,10 @@ namespace Serilog.Sinks.MySQL
             _tableName = tableName;
             _storeTimestampInUtc = storeTimestampInUtc;
 
-            var sqlConnection = GetSqlConnection();
-            CreateTable(sqlConnection);
+            using (var sqlConnection = GetSqlConnection())
+            {
+                CreateTable(sqlConnection);
+            }
         }
 
         public void Emit(LogEvent logEvent)


### PR DESCRIPTION
Was hoping to possibly share this switch as MySqlConnector provides a drop-in replacement for Oracle's MySql.Data library, which does not use a permissive license.